### PR TITLE
CROSSEVAL-57 Bug solves

### DIFF
--- a/BackEnd/CrossEval/app/Http/Controllers/Api/AssignmentController.php
+++ b/BackEnd/CrossEval/app/Http/Controllers/Api/AssignmentController.php
@@ -114,8 +114,9 @@ class AssignmentController extends Controller
 
             $data = $users_assignment->map(function ($user_id) use ($assignment) {
                 return [
-                    'user_id' => $user_id,
+                    'user_id'       => $user_id,
                     'assignment_id' => $assignment->id,
+                    'status'        => Answer::STATUS_FUTURE,
                 ];
             });
 

--- a/BackEnd/CrossEval/app/Http/Controllers/Api/CourseController.php
+++ b/BackEnd/CrossEval/app/Http/Controllers/Api/CourseController.php
@@ -11,6 +11,7 @@ use App\Models\Course;
 use App\Models\UserCourse;
 use App\Models\User;
 use App\Services\Course\Syllabus\Create\Service as AddSyllabusService;
+use http\Env\Response;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Validator;
@@ -32,6 +33,12 @@ class CourseController extends Controller
         $courses     = Course::whereIn('id', $course_list)
             ->where('name', 'like', '%' . $request->search . '%')
             ->get();
+
+        if (!isset($courses)){
+            return response()->json([
+                'message' => 'You are not enrolled to this course',
+            ]);
+        }
 
         return response()->json([
             'courses' => CourseSummaryResource::collection($courses),

--- a/BackEnd/CrossEval/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/BackEnd/CrossEval/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -35,7 +35,7 @@ class RegisteredUserController extends Controller
 //            'birthday'      => ['date_format:Y-m-d', 'max:255'],
             'email'         => ['required', 'string', 'email', 'max:255', 'unique:'.User::class],
             'password'      => ['required', 'confirmed', Rules\Password::defaults()],
-            'university_id' => ['required', 'integer'],
+            'university_id' => ['integer'],
         ], [
             'name.required'          => 'The name field is required.',
             'name.string'            => 'The name must be a string.',
@@ -62,7 +62,6 @@ class RegisteredUserController extends Controller
             'email.unique'           => 'The email has already been taken.',
             'password.required'      => 'The password field is required.',
             'password.confirmed'     => 'The password confirmation does not match.',
-            'university_id.required' => 'The university_ud field is required.',
         ]);
 
         if ($validator->fails()) {

--- a/BackEnd/CrossEval/app/Http/Resources/AnswerReviewResource.php
+++ b/BackEnd/CrossEval/app/Http/Resources/AnswerReviewResource.php
@@ -26,10 +26,11 @@ class AnswerReviewResource extends JsonResource
         $status = ($this->criteria_grade !== null) ? 'Checked' : 'To Check';
 
         $data = [
-            'grade'    => $overall,
-            'criteria' => $this->criteria_grade,
-            'comment'  => $this->comment,
-            'status'   => $status,
+            'answer_id' => $this->answer_id,
+            'grade'     => $overall,
+            'criteria'  => $this->criteria_grade,
+            'comment'   => $this->comment,
+            'status'    => $status,
         ];
 
         return $data;


### PR DESCRIPTION
If a student wants to know information about a course for which he/she is not enrolled, access to it will be denied.

On the registration page. University_id field is not required.

Added answer_id for all cross_reviews pages.

Changed the status of the assignment's answers for the students initially as the "Future". Because they are not be able to access the assignment before the start date has come.