### PR TITLE
CROSSEVAL-58 API to remove student from course

### DIFF
--- a/BackEnd/CrossEval/routes/api.php
+++ b/BackEnd/CrossEval/routes/api.php
@@ -55,5 +55,6 @@ Route::prefix('v1')->namespace('App\Http\Controllers\Api')->group(function () {
         Route::get('/user/supervisor/grades', 'UserController@supervisor_grades');
         Route::post('/user/profile',          'UserController@profile_update');
         Route::delete('/user',                'UserController@delete');
+        Route::delete('/user/course',         'UserController@remove_from_course');
     });
 });


### PR DESCRIPTION
Added API to remove students from the course

This is allowed only for the student or supervisor leading the course to delete everyone in his course.

Notice that when the student leaves the course all his answers and reviews are deleted too.